### PR TITLE
R/filtfilt.R: Better method for reflecting signal before filtering

### DIFF
--- a/R/filtfilt.R
+++ b/R/filtfilt.R
@@ -125,8 +125,8 @@ filtfilt.default <- function(filt, a, x, ...) {
 
   for (icol in seq_len(ncx)) {
     if (nfact > 0) {
-      temp <- c(x[seq(nfact + 1, 2, -1), icol], x[, icol],
-                x[seq(nrx - 1, nrx - nfact, -1), icol])
+      temp <- c(2 * x[1, icol] - x[seq(nfact + 1, 2, -1), icol], x[, icol],
+                2 * x[nrx, icol] - x[seq(nrx - 1, nrx - nfact, -1), icol])
       temp <- filter(filt, a, temp, zi * temp[1])$y
       temp <- rev(temp)
       temp <- rev(filter(filt, a, temp, zi * temp[1])$y)


### PR DESCRIPTION
The reflection on both sides of the signal prior to filtering can be improved by negating the signal reversed in time. This ensures the continuity of the first derivative of the resulting expanded signal, reducing the border effects.

This technique is currently used in the [filtfilt function of Octave](https://sourceforge.net/p/octave/signal/ci/default/tree/inst/filtfilt.m).

The improvement can be shown in the following image, for a ramp signal:

![Screenshot from 2022-12-16 17-55-06](https://user-images.githubusercontent.com/4037976/208152107-0a970b0d-c273-4184-a70f-9bfe2a12e40b.png)

This figure was obtained with the following code:

```r
library (gsignal)
x <- seq (0, 50)
f <- butter (3, 0.1)
plot (x, pch = 19, col = "gray")
cols = c ("#ff000080", "#0000ff80")
lines (filtfilt(f,x), col = cols [1], lwd = 3)
source ("R/filtfilt.R")
lines (filtfilt(f,x), col = cols [2], lwd = 3)
legend ("topleft", inset = 0.05, col = cols, lwd = 3,
        legend = c ("original", "improved"))
```
